### PR TITLE
[PROPOSAL] Rename gem to Sapience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ReevooSapience
+# Sapience
 
 Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/reevoo_sapience`. To experiment with that code, run `bin/console` for an interactive prompt.
 
@@ -9,7 +9,7 @@ TODO: Delete this and the text above, and describe your gem
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'reevoo_sapience'
+gem 'sapience'
 ```
 
 And then execute:
@@ -18,7 +18,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install reevoo_sapience
+    $ gem install sapience
 
 ## Usage
 
@@ -32,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/reevoo_sapience. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/reevoo/sapience. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 
 ## License


### PR DESCRIPTION
Yo!  Just noticed this repo and thought I'd throw out the suggestion
that there's no need to call it "reevoo_sapience", when we can just call
it "sapience" (I checked, that doesn't exist on rubygems yet)

This is a proposed first commit for that, given it would mean renaming
the project and the files, thought I'd leave it up to you guys to deal
with if you want.....

Tell me to sod off and stop being a nosy dick if you want :)