### PR TITLE
Pin gem sentry-raven to 2.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.3.2
+- Pin sentry-raven gem to "~> 2.6.x"
+  There was an issue with sentry-raven@2.7.0 so we are restricting it to the 2.6.x
+  range.
+  https://github.com/getsentry/raven-ruby/issues/773
+
 ## v2.3.1
 - Bump sentry-raven gem to "~> 2.6"
 

--- a/lib/reevoo_sapience/version.rb
+++ b/lib/reevoo_sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ReevooSapience
-  VERSION = "2.3.1"
+  VERSION = "2.3.2"
 end

--- a/reevoo_sapience-rb.gemspec
+++ b/reevoo_sapience-rb.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sapience", "~> 2.2"
   spec.add_dependency "dogstatsd-ruby", "~> 2.2"
-  spec.add_dependency "sentry-raven", "~> 2.6"
+  spec.add_dependency "sentry-raven", "~> 2.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
There was an issue with gem raven-sentry v2.7.0 so we better pin it to
2.6.x for now.

https://github.com/getsentry/raven-ruby/issues/773