### PR TITLE
Use color log formatter for staging by default

### DIFF
--- a/lib/default_reevoo_sapience.yml
+++ b/lib/default_reevoo_sapience.yml
@@ -63,7 +63,7 @@ staging:
   appenders:
     - stream:
         io: STDOUT
-        formatter: json
+        formatter: color
 
 ci:
   log_level: warn


### PR DESCRIPTION
We don't send staging logs to datadog anymore so there is no point to compromise readability